### PR TITLE
Set default docker version to 1.7.0.

### DIFF
--- a/manifests/garethr.pp
+++ b/manifests/garethr.pp
@@ -1,5 +1,5 @@
 class docker_hardening::garethr (
-        $version = '1.6',
+        $version = '1.7.0',
         )
 {
     class { 'docker':

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.2.0"},
     {"name":"garethr/docker", "version_requirement": ">= 4.1.1"},
-    {"name":"puppetlabs/apt"}
+    {"name":"puppetlabs/apt", "version_requirement": ">= 2.2.0"}
 
   ]
 }


### PR DESCRIPTION
- This is the newest supported version for ubuntu 14.04.
- Pin apt module to 2.2.0 to avoid latest greatest issues.
